### PR TITLE
Reduce mixin visibilities

### DIFF
--- a/src/main/java/selic/re/discordbridge/mixin/BroadcastHandlerMixin.java
+++ b/src/main/java/selic/re/discordbridge/mixin/BroadcastHandlerMixin.java
@@ -12,9 +12,9 @@ import selic.re.discordbridge.DiscordBot;
 import java.util.UUID;
 
 @Mixin(PlayerManager.class)
-public class BroadcastHandlerMixin {
+abstract class BroadcastHandlerMixin {
     @Inject(at = @At("HEAD"), method = "broadcastChatMessage")
-    public void preBroadcastChatMessage(Text message, MessageType type, UUID sender, CallbackInfo info) {
+    private void preBroadcastChatMessage(Text message, MessageType type, UUID sender, CallbackInfo info) {
         DiscordBot.getInstance().ifPresent(db -> db.sendSystemMessage(message));
     }
 }

--- a/src/main/java/selic/re/discordbridge/mixin/NetworkHandlerMixin.java
+++ b/src/main/java/selic/re/discordbridge/mixin/NetworkHandlerMixin.java
@@ -1,22 +1,20 @@
 package selic.re.discordbridge.mixin;
 
 import com.mojang.authlib.GameProfile;
+import net.minecraft.network.listener.ServerPlayPacketListener;
 import net.minecraft.server.filter.TextStream;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
-import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.EntityTrackingListener;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import selic.re.discordbridge.DiscordBot;
 
 @Mixin(ServerPlayNetworkHandler.class)
-public abstract class NetworkHandlerMixin {
-	@Shadow public abstract ServerPlayerEntity getPlayer();
-
+abstract class NetworkHandlerMixin implements EntityTrackingListener, ServerPlayPacketListener {
 	@Inject(at = @At("HEAD"), method = "handleMessage")
-	public void preMessage(TextStream.Message message, CallbackInfo info) {
+	private void preMessage(TextStream.Message message, CallbackInfo info) {
 		String msg = message.getRaw();
 		if (!msg.startsWith("/")) {
 			GameProfile player = this.getPlayer().getGameProfile();

--- a/src/main/java/selic/re/discordbridge/mixin/PlayerManagerMixin.java
+++ b/src/main/java/selic/re/discordbridge/mixin/PlayerManagerMixin.java
@@ -10,7 +10,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import selic.re.discordbridge.DiscordBot;
 
 @Mixin(PlayerManager.class)
-public class PlayerManagerMixin {
+abstract class PlayerManagerMixin {
     @Inject(method = "remove(Lnet/minecraft/server/network/ServerPlayerEntity;)V", at = @At("RETURN"))
     private void remove(CallbackInfo ci) {
         DiscordBot.getInstance().ifPresent(DiscordBot::onPlayersChanged);


### PR DESCRIPTION
 - Reduced visibility of injectors to allow for obfuscation. In a mixin environment, the processor can only obfuscate members that are not publically accessible. By reducing the visibility, we are allowing Mixin to obfuscate these members, reducing the risk of conflict with other members injected by third-party mixins.
 - Reduced visibility of mixin classes to discourage accidental references. This is common practice for mixins, simply for the fact that it makes these classes inaccessible at source level to other code in the workspace, preventing accidental references to mixin classes (which cannot be referenced at runtime). Applying the abstract modifier helps further as an indicator that these classes are not intended for use by anything other than the Mixin annotation processor.
 - Extended hierarchy of mixin classes to include superclasses of the target, allowing for stricter matching at runtime, and the use of superclass methods

You can learn more about Mixin hierarchy here:
https://github.com/SpongePowered/Mixin/wiki/Introduction-to-Mixins---Understanding-Mixin-Architecture
And the application process here:
https://github.com/SpongePowered/Mixin/wiki/Flippin'-Mixins,-how-do-they-work%3F#3321-creating-the-applicator-and-pre-processing-mixins