### PR TITLE
Refactor attachment formatting to provide more immediate detail

### DIFF
--- a/src/main/java/selic/re/discordbridge/DiscordBot.java
+++ b/src/main/java/selic/re/discordbridge/DiscordBot.java
@@ -125,16 +125,11 @@ public class DiscordBot extends ListenerAdapter {
             if (!msg.getAttachments().isEmpty()) {
                 for (Message.Attachment attachment : msg.getAttachments()) {
                     root.append(" [");
-                    LiteralText text;
-                    if (attachment.isImage()) {
-                        text = new LiteralText("image");
-                    } else if (attachment.isVideo()) {
-                        text = new LiteralText("video");
-                    } else {
-                        text = new LiteralText("attachment");
-                    }
+                    LiteralText text = new LiteralText(attachment.getFileName());
                     ClickEvent click = new ClickEvent(ClickEvent.Action.OPEN_URL, attachment.getUrl());
-                    HoverEvent hover = new HoverEvent(HoverEvent.Action.SHOW_TEXT, new LiteralText(attachment.getFileName() + "\n" + (attachment.getSize() / 1000) + " kb"));
+                    HoverEvent hover = new HoverEvent(HoverEvent.Action.SHOW_TEXT, new LiteralText(
+                        "%s%n%.2fKB".formatted(attachment.getContentType(), attachment.getSize() / 1000.0)
+                    ));
                     text.setStyle(Style.EMPTY.withClickEvent(click).withHoverEvent(hover));
                     root.append(text);
                     root.append("]");

--- a/src/main/java/selic/re/discordbridge/DiscordBot.java
+++ b/src/main/java/selic/re/discordbridge/DiscordBot.java
@@ -127,7 +127,7 @@ public class DiscordBot extends ListenerAdapter {
             if (!msg.getAttachments().isEmpty()) {
                 for (Message.Attachment attachment : msg.getAttachments()) {
                     root.append(" [");
-                    // If the file is intended to be hidden by a spoiler ,we wrap it with exclamation marks: [!file.txt!]
+                    // If the file is intended to be hidden by a spoiler, we wrap it with exclamation marks: [!file.txt!]
                     LiteralText text = new LiteralText(FILE_SPOILER.matcher(attachment.getFileName()).replaceFirst("!$1!"));
                     ClickEvent click = new ClickEvent(ClickEvent.Action.OPEN_URL, attachment.getUrl());
                     // Display the media type and readable file size in the on mouse-over: text/plain | 103 bytes

--- a/src/main/java/selic/re/discordbridge/DiscordBot.java
+++ b/src/main/java/selic/re/discordbridge/DiscordBot.java
@@ -146,11 +146,11 @@ public class DiscordBot extends ListenerAdapter {
     private static String readableFileSize(Message.Attachment attachment) {
         int size = attachment.getSize();
 
-        if (Double.compare(size / (1024.0 * 1024.0), 0.0) > 0) {
+        if ((size / (1024 * 1024)) > 0) {
             return "%.2f MB".formatted(size / (1024.0 * 1024.0));
         }
 
-        if (Double.compare(size / 1024.0, 0.0) > 0) {
+        if ((size / 1024) > 0) {
             return "%.2f KB".formatted(size / 1024.0);
         }
 

--- a/src/main/java/selic/re/discordbridge/DiscordBot.java
+++ b/src/main/java/selic/re/discordbridge/DiscordBot.java
@@ -127,9 +127,10 @@ public class DiscordBot extends ListenerAdapter {
             if (!msg.getAttachments().isEmpty()) {
                 for (Message.Attachment attachment : msg.getAttachments()) {
                     root.append(" [");
-                    // If the file is intended to be hidden by a spoiler ,we wrap it with exclamation marks [!file.txt!]
+                    // If the file is intended to be hidden by a spoiler ,we wrap it with exclamation marks: [!file.txt!]
                     LiteralText text = new LiteralText(FILE_SPOILER.matcher(attachment.getFileName()).replaceFirst("!$1!"));
                     ClickEvent click = new ClickEvent(ClickEvent.Action.OPEN_URL, attachment.getUrl());
+                    // Display the media type and readable file size in the on mouse-over: text/plain | 103 bytes
                     HoverEvent hover = new HoverEvent(HoverEvent.Action.SHOW_TEXT, new LiteralText(
                         "%s | %s".formatted(attachment.getContentType(), readableFileSize(attachment))
                     ));

--- a/src/main/java/selic/re/discordbridge/DiscordBot.java
+++ b/src/main/java/selic/re/discordbridge/DiscordBot.java
@@ -3,7 +3,6 @@ package selic.re.discordbridge;
 import club.minnced.discord.webhook.WebhookClient;
 import club.minnced.discord.webhook.WebhookClientBuilder;
 import club.minnced.discord.webhook.send.WebhookMessageBuilder;
-import com.google.common.base.MoreObjects;
 import com.mojang.authlib.GameProfile;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;


### PR DESCRIPTION
 - [Media type](https://en.wikipedia.org/wiki/Media_type) and file size are now used for the message:
   - `[image/png | 12.63 KB]`
   - `[text/plain | 103 bytes]`
   - `[image/jpeg | 1.20 MB]`

