### PR TITLE
Add support for timestamp markdown

### DIFF
--- a/src/main/java/selic/re/discordbridge/DiscordFormattingConverter.java
+++ b/src/main/java/selic/re/discordbridge/DiscordFormattingConverter.java
@@ -324,7 +324,7 @@ public class DiscordFormattingConverter {
             .append(TIMESTAMP_FORMATS.get(timestamp.getFormat()).formatted(dateTime))
             .append("]")
             .setStyle(Style.EMPTY.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
-                new LiteralText(TIMESTAMP_FORMATS.get(TimeFormat.DATE_TIME_SHORT).formatted(dateTime))
+                new LiteralText(TIMESTAMP_FORMATS.get(TimeFormat.DATE_TIME_LONG).formatted(dateTime))
             )).withInsertion(timestamp.toString()));
     }
 

--- a/src/main/java/selic/re/discordbridge/DiscordFormattingConverter.java
+++ b/src/main/java/selic/re/discordbridge/DiscordFormattingConverter.java
@@ -111,7 +111,7 @@ public class DiscordFormattingConverter {
      * @return The first captured group or null if absent
      */
     @Nullable
-    protected String consumeMatching(final Pattern pattern) {
+    protected String consumeFirst(final Pattern pattern) {
         final var input = this.markdown.substring(this.cursor);
         if (input.isEmpty()) { // Nothing to match
             return null;
@@ -221,7 +221,7 @@ public class DiscordFormattingConverter {
                 return true;
             }
         }
-        String result = consumeMatching(TIMESTAMP_PATTERN);
+        String result = consumeFirst(TIMESTAMP_PATTERN);
         if (result != null) {
             addTimestamp(TimeFormat.parse(result));
             return true;


### PR DESCRIPTION
Formatted as per the [official specification reference](https://discord.com/developers/docs/reference#message-formatting-timestamp-styles), bar `Relative`, which is formatted as the default `Short Date/Time`.