### PR TITLE
Port to Fabric 1.19 and use the new fabric-message-api decorator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import org.gradle.util.GradleVersion
 import java.time.Instant
 
 plugins {
-    id "fabric-loom" version "0.12-SNAPSHOT"
+    id "fabric-loom" version "0.12.48"
     id "io.github.juuxel.loom-quiltflower" version "1.7.2"
     id "net.nemerosa.versioning" version "2.15.1"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -45,13 +45,13 @@ configurations {
 }
 
 dependencies {
-    minecraft "com.mojang:minecraft:1.19-rc2"
-    mappings "net.fabricmc:yarn:1.19-rc2+build.1:v2"
+    minecraft "com.mojang:minecraft:1.19"
+    mappings "net.fabricmc:yarn:1.19+build.1:v2"
     modImplementation "net.fabricmc:fabric-loader:0.14.6"
 
-    modImplementation include(fabricApi.module("fabric-api-base", "0.55.1+1.19"))
-    modImplementation include(fabricApi.module("fabric-lifecycle-events-v1", "0.55.1+1.19"))
-    modImplementation include(fabricApi.module("fabric-message-api-v1", "0.55.1+1.19"))
+    modImplementation include(fabricApi.module("fabric-api-base", "0.55.2+1.19"))
+    modImplementation include(fabricApi.module("fabric-lifecycle-events-v1", "0.55.2+1.19"))
+    modImplementation include(fabricApi.module("fabric-message-api-v1", "0.55.2+1.19"))
 
     implementation(transitiveInclude("net.dv8tion:JDA:5.0.0-alpha.9")) {
         exclude module: "opus-java"

--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@ import org.gradle.util.GradleVersion
 import java.time.Instant
 
 plugins {
-    id "fabric-loom" version "0.12.5"
-    id "io.github.juuxel.loom-quiltflower" version "1.6.1"
+    id "fabric-loom" version "0.12-SNAPSHOT"
+    id "io.github.juuxel.loom-quiltflower" version "1.7.2"
     id "net.nemerosa.versioning" version "2.15.1"
 }
 
@@ -45,12 +45,13 @@ configurations {
 }
 
 dependencies {
-    minecraft "com.mojang:minecraft:1.18.2"
-    mappings "net.fabricmc:yarn:1.18.2+build.2:v2"
-    modImplementation "net.fabricmc:fabric-loader:0.13.3"
+    minecraft "com.mojang:minecraft:1.19-rc2"
+    mappings "net.fabricmc:yarn:1.19-rc2+build.1:v2"
+    modImplementation "net.fabricmc:fabric-loader:0.14.6"
 
-    modImplementation include(fabricApi.module("fabric-api-base", "0.48.0+1.18.2"))
-    modImplementation include(fabricApi.module("fabric-lifecycle-events-v1", "0.48.0+1.18.2"))
+    modImplementation include(fabricApi.module("fabric-api-base", "0.55.1+1.19"))
+    modImplementation include(fabricApi.module("fabric-lifecycle-events-v1", "0.55.1+1.19"))
+    modImplementation include(fabricApi.module("fabric-message-api-v1", "0.55.1+1.19"))
 
     implementation(transitiveInclude("net.dv8tion:JDA:5.0.0-alpha.9")) {
         exclude module: "opus-java"

--- a/src/main/java/selic/re/discordbridge/DiscordBot.java
+++ b/src/main/java/selic/re/discordbridge/DiscordBot.java
@@ -34,7 +34,7 @@ public interface DiscordBot {
     void sendMessage(GameProfile sender, String message);
 
     @Nullable
-    Text formatAndSendMessage(GameProfile sender, String message);
+    Text formatAndSendMessage(GameProfile sender, Text message);
 
 
     void onPlayersChanged();

--- a/src/main/java/selic/re/discordbridge/DiscordBotImpl.java
+++ b/src/main/java/selic/re/discordbridge/DiscordBotImpl.java
@@ -128,7 +128,7 @@ class DiscordBotImpl extends ListenerAdapter implements DiscordBot {
 
     @Override
     public void onReady(@NotNull ReadyEvent event) {
-        this.sendMessage(Text.of("Hello friends! The server is up <3"));
+        this.sendMessage(Text.literal("Hello friends! The server is up <3"));
     }
 
     @Override
@@ -169,7 +169,7 @@ class DiscordBotImpl extends ListenerAdapter implements DiscordBot {
                     MutableText message = Text.empty()
                         .append(discordUserToMinecraft(event.getUser(), getGuild(), false))
                         .append(" is now streaming to ")
-                        .append(Text.empty().append(streamLink).setStyle(Style.EMPTY.withUnderline(true).withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, streamLink))));
+                        .append(Text.literal(streamLink).setStyle(Style.EMPTY.withUnderline(true).withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, streamLink))));
                     if (config.hideChatFromStreamers) {
                         message.append(" - Chat has been disabled.");
                     }
@@ -255,7 +255,7 @@ class DiscordBotImpl extends ListenerAdapter implements DiscordBot {
 
             Message refMsg = msg.getReferencedMessage();
             if (refMsg != null) {
-                MutableText arrow = Text.empty().append("[->]");
+                MutableText arrow = Text.literal("[->]");
                 if (!refMsg.getContentRaw().isBlank()) {
                     arrow.setStyle(Style.EMPTY.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, discordMessageToMinecraft(refMsg))));
                 }
@@ -272,30 +272,29 @@ class DiscordBotImpl extends ListenerAdapter implements DiscordBot {
             if (!msg.getAttachments().isEmpty()) {
                 for (Message.Attachment attachment : msg.getAttachments()) {
                     root.append(" [");
-                    MutableText fileType = Text.empty();
+                    MutableText fileType = null;
                     if (attachment.isImage()) {
-                        fileType.append("image");
+                        fileType = Text.literal("image");
                     } else if (attachment.isVideo()) {
-                        fileType.append("video");
+                        fileType = Text.literal("video");
                     } else {
                         @Nullable String mediaType = attachment.getContentType();
                         if (mediaType != null) {
                             if (mediaType.startsWith("text")) {
-                                fileType.append("text");
+                                fileType = Text.literal("text");
                             } else if (mediaType.startsWith("audio")) {
-                                fileType.append("audio");
-                            } else {
-                                fileType.append("attachment");
+                                fileType = Text.literal("audio");
                             }
-                        } else {
-                            fileType.append("attachment");
+                        }
+                        if (fileType == null) {
+                            fileType = Text.literal("attachment");
                         }
                     }
                     ClickEvent click = new ClickEvent(ClickEvent.Action.OPEN_URL, attachment.getUrl());
                     HoverEvent hover = new HoverEvent(HoverEvent.Action.SHOW_TEXT, Text.empty()
                         .append(attachment.getFileName())
                         .append("\n")
-                        .append(Text.of(readableFileSize(attachment.getSize()))));
+                        .append(readableFileSize(attachment.getSize())));
                     fileType.setStyle(Style.EMPTY.withClickEvent(click).withHoverEvent(hover));
                     root.append(fileType);
                     root.append("]");

--- a/src/main/java/selic/re/discordbridge/DiscordBridgeMod.java
+++ b/src/main/java/selic/re/discordbridge/DiscordBridgeMod.java
@@ -2,7 +2,9 @@ package selic.re.discordbridge;
 
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.fabricmc.fabric.api.message.v1.ServerMessageDecoratorEvent;
 import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.text.Text;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -10,6 +12,7 @@ import javax.annotation.Nullable;
 import javax.security.auth.login.LoginException;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
 
 public class DiscordBridgeMod implements ModInitializer {
     private static final Logger LOGGER = LogManager.getLogger();
@@ -36,6 +39,15 @@ public class DiscordBridgeMod implements ModInitializer {
 
         ServerLifecycleEvents.SERVER_STOPPED.register(server -> {
             DiscordBot.instance().shutdown();
+        });
+
+        ServerMessageDecoratorEvent.EVENT.register(ServerMessageDecoratorEvent.STYLING_PHASE, (sender, message) -> {
+            if (sender != null) {
+                Text messageText = DiscordBot.instance().formatAndSendMessage(sender.getGameProfile(), message);
+                return CompletableFuture.completedFuture(messageText);
+            }
+
+            return CompletableFuture.completedFuture(message);
         });
     }
 }

--- a/src/main/java/selic/re/discordbridge/DiscordCommandOutput.java
+++ b/src/main/java/selic/re/discordbridge/DiscordCommandOutput.java
@@ -42,7 +42,7 @@ public class DiscordCommandOutput implements CommandOutput {
     }
 
     @Override
-    public void sendSystemMessage(Text text, UUID sender) {
+    public void sendMessage(Text text) {
         lock.lock();
         try {
             if (scheduledFlush != null) {

--- a/src/main/java/selic/re/discordbridge/DiscordFormattingConverter.java
+++ b/src/main/java/selic/re/discordbridge/DiscordFormattingConverter.java
@@ -15,11 +15,7 @@ import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.utils.TimeFormat;
 import net.dv8tion.jda.api.utils.Timestamp;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.text.ClickEvent;
-import net.minecraft.text.HoverEvent;
-import net.minecraft.text.LiteralText;
-import net.minecraft.text.Style;
-import net.minecraft.text.Text;
+import net.minecraft.text.*;
 
 import javax.annotation.Nullable;
 import java.time.LocalDateTime;
@@ -86,7 +82,7 @@ public class DiscordFormattingConverter {
     private final Message message;
     private final String markdown;
     private int cursor;
-    private final LiteralText root = new LiteralText("");
+    private final MutableText root = Text.empty();
     private List<ActiveFormatting> formattingStack = new ArrayList<>();
     private Set<Formatting> activeFormatting = EnumSet.noneOf(Formatting.class);
     final StringBuilder textBuffer = new StringBuilder();
@@ -177,7 +173,7 @@ public class DiscordFormattingConverter {
     }
 
     private void popSimpleText() {
-        LiteralText text = new LiteralText(textBuffer.toString());
+        Text text = Text.of(textBuffer.toString());
         textBuffer.setLength(0);
         addText(text);
     }
@@ -188,7 +184,7 @@ public class DiscordFormattingConverter {
         if (danglingToken) {
             textBuffer.insert(entry.offset, entry.trigger);
         }
-        LiteralText text = new LiteralText(textBuffer.toString());
+        MutableText text = Text.empty().append(textBuffer.toString());
         textBuffer.setLength(0);
         if (!danglingToken) {
             text.setStyle(entry.formatting.getStyle(text));
@@ -250,7 +246,7 @@ public class DiscordFormattingConverter {
     }
 
     private void addRoleMention(Role role) {
-        LiteralText text = new LiteralText("@" + role.getName());
+        MutableText text = Text.empty().append("@" + role.getName());
         text.setStyle(Style.EMPTY.withColor(role.getColorRaw()).withInsertion(role.getAsMention()));
         popSimpleText();
         addText(text);
@@ -288,8 +284,8 @@ public class DiscordFormattingConverter {
         String name = (channel.getType().isMessage() ? "#" : "") + channel.getName();
         String type = CHANNEL_TYPE_STRINGIFIER.apply(channel.getType().name());
 
-        return new LiteralText(name).setStyle(Style.EMPTY.withInsertion(channel.getAsMention())
-            .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new LiteralText(type))));
+        return Text.empty().append(name).setStyle(Style.EMPTY.withInsertion(channel.getAsMention())
+            .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Text.of(type))));
     }
 
     public static Text discordMessageToMinecraft(Message message) {
@@ -298,17 +294,17 @@ public class DiscordFormattingConverter {
         return converter.root;
     }
 
-    public static LiteralText discordEmoteToMinecraft(Emote emote) {
-        LiteralText text = new LiteralText(":" + emote.getName() + ":");
+    public static MutableText discordEmoteToMinecraft(Emote emote) {
+        MutableText text = Text.empty().append(":" + emote.getName() + ":");
         ClickEvent click = new ClickEvent(ClickEvent.Action.OPEN_URL, emote.getImageUrl());
-        HoverEvent hover = new HoverEvent(HoverEvent.Action.SHOW_TEXT, new LiteralText(emote.getGuild() == null ? "Emote" : "Emote from " + emote.getGuild().getName()));
+        HoverEvent hover = new HoverEvent(HoverEvent.Action.SHOW_TEXT, Text.of(emote.getGuild() == null ? "Emote" : "Emote from " + emote.getGuild().getName()));
         text.setStyle(Style.EMPTY.withClickEvent(click).withHoverEvent(hover).withInsertion(":" + emote.getName() + ":"));
         return text;
     }
 
     public static Text discordUserToMinecraft(User user, Guild guild, boolean asMention) {
         @Nullable Member member = guild.getMember(user);
-        LiteralText tooltip = new LiteralText(user.getAsTag());
+        MutableText tooltip = Text.empty().append(user.getAsTag());
         String userName = user.getName();
         Style style = Style.EMPTY;
         boolean online = false;
@@ -337,7 +333,7 @@ public class DiscordFormattingConverter {
 
             for (Role role : roles) {
                 tooltip.append("\n- ");
-                tooltip.append(new LiteralText(role.getName())
+                tooltip.append(Text.empty().append(role.getName())
                     .setStyle(Style.EMPTY.withColor(role.getColorRaw())));
             }
         }
@@ -346,7 +342,7 @@ public class DiscordFormattingConverter {
             userName = "@" + userName;
         }
 
-        return new LiteralText(userName).setStyle(style.withInsertion("@" + user.getAsTag())
+        return Text.empty().append(userName).setStyle(style.withInsertion("@" + user.getAsTag())
             .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, tooltip)));
     }
 
@@ -364,11 +360,11 @@ public class DiscordFormattingConverter {
     public static Text discordTimestampToMinecraft(Timestamp timestamp) {
         // TODO Allow configuration of preferred time zone and hour (24/12) format?
         LocalDateTime dateTime = LocalDateTime.ofInstant(timestamp.toInstant(), ZoneOffset.UTC);
-        return new LiteralText("[")
+        return Text.empty().append("[")
             .append(TIMESTAMP_FORMATS.get(timestamp.getFormat()).formatted(dateTime))
             .append("]")
             .setStyle(Style.EMPTY.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
-                new LiteralText(TIMESTAMP_FORMATS.get(TimeFormat.DATE_TIME_LONG).formatted(dateTime))
+                Text.of(TIMESTAMP_FORMATS.get(TimeFormat.DATE_TIME_LONG).formatted(dateTime))
             )).withInsertion(timestamp.toString()));
     }
 

--- a/src/main/java/selic/re/discordbridge/DiscordFormattingConverter.java
+++ b/src/main/java/selic/re/discordbridge/DiscordFormattingConverter.java
@@ -173,7 +173,7 @@ public class DiscordFormattingConverter {
     }
 
     private void popSimpleText() {
-        Text text = Text.of(textBuffer.toString());
+        Text text = Text.literal(textBuffer.toString());
         textBuffer.setLength(0);
         addText(text);
     }
@@ -184,7 +184,7 @@ public class DiscordFormattingConverter {
         if (danglingToken) {
             textBuffer.insert(entry.offset, entry.trigger);
         }
-        MutableText text = Text.empty().append(textBuffer.toString());
+        MutableText text = Text.literal(textBuffer.toString());
         textBuffer.setLength(0);
         if (!danglingToken) {
             text.setStyle(entry.formatting.getStyle(text));
@@ -246,7 +246,7 @@ public class DiscordFormattingConverter {
     }
 
     private void addRoleMention(Role role) {
-        MutableText text = Text.empty().append("@" + role.getName());
+        MutableText text = Text.literal("@" + role.getName());
         text.setStyle(Style.EMPTY.withColor(role.getColorRaw()).withInsertion(role.getAsMention()));
         popSimpleText();
         addText(text);
@@ -284,8 +284,8 @@ public class DiscordFormattingConverter {
         String name = (channel.getType().isMessage() ? "#" : "") + channel.getName();
         String type = CHANNEL_TYPE_STRINGIFIER.apply(channel.getType().name());
 
-        return Text.empty().append(name).setStyle(Style.EMPTY.withInsertion(channel.getAsMention())
-            .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Text.of(type))));
+        return Text.literal(name).setStyle(Style.EMPTY.withInsertion(channel.getAsMention())
+            .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Text.literal(type))));
     }
 
     public static Text discordMessageToMinecraft(Message message) {
@@ -295,16 +295,16 @@ public class DiscordFormattingConverter {
     }
 
     public static MutableText discordEmoteToMinecraft(Emote emote) {
-        MutableText text = Text.empty().append(":" + emote.getName() + ":");
+        MutableText text = Text.literal(":" + emote.getName() + ":");
         ClickEvent click = new ClickEvent(ClickEvent.Action.OPEN_URL, emote.getImageUrl());
-        HoverEvent hover = new HoverEvent(HoverEvent.Action.SHOW_TEXT, Text.of(emote.getGuild() == null ? "Emote" : "Emote from " + emote.getGuild().getName()));
+        HoverEvent hover = new HoverEvent(HoverEvent.Action.SHOW_TEXT, Text.literal(emote.getGuild() == null ? "Emote" : "Emote from " + emote.getGuild().getName()));
         text.setStyle(Style.EMPTY.withClickEvent(click).withHoverEvent(hover).withInsertion(":" + emote.getName() + ":"));
         return text;
     }
 
     public static Text discordUserToMinecraft(User user, Guild guild, boolean asMention) {
         @Nullable Member member = guild.getMember(user);
-        MutableText tooltip = Text.empty().append(user.getAsTag());
+        MutableText tooltip = Text.literal(user.getAsTag());
         String userName = user.getName();
         Style style = Style.EMPTY;
         boolean online = false;
@@ -333,7 +333,7 @@ public class DiscordFormattingConverter {
 
             for (Role role : roles) {
                 tooltip.append("\n- ");
-                tooltip.append(Text.empty().append(role.getName())
+                tooltip.append(Text.literal(role.getName())
                     .setStyle(Style.EMPTY.withColor(role.getColorRaw())));
             }
         }
@@ -342,7 +342,7 @@ public class DiscordFormattingConverter {
             userName = "@" + userName;
         }
 
-        return Text.empty().append(userName).setStyle(style.withInsertion("@" + user.getAsTag())
+        return Text.literal(userName).setStyle(style.withInsertion("@" + user.getAsTag())
             .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, tooltip)));
     }
 
@@ -360,11 +360,11 @@ public class DiscordFormattingConverter {
     public static Text discordTimestampToMinecraft(Timestamp timestamp) {
         // TODO Allow configuration of preferred time zone and hour (24/12) format?
         LocalDateTime dateTime = LocalDateTime.ofInstant(timestamp.toInstant(), ZoneOffset.UTC);
-        return Text.empty().append("[")
+        return Text.literal("[")
             .append(TIMESTAMP_FORMATS.get(timestamp.getFormat()).formatted(dateTime))
             .append("]")
             .setStyle(Style.EMPTY.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
-                Text.of(TIMESTAMP_FORMATS.get(TimeFormat.DATE_TIME_LONG).formatted(dateTime))
+                Text.literal(TIMESTAMP_FORMATS.get(TimeFormat.DATE_TIME_LONG).formatted(dateTime))
             )).withInsertion(timestamp.toString()));
     }
 

--- a/src/main/java/selic/re/discordbridge/GameMessageConverter.java
+++ b/src/main/java/selic/re/discordbridge/GameMessageConverter.java
@@ -4,7 +4,9 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Emote;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.TextChannel;
-import net.minecraft.text.LiteralText;
+import net.minecraft.text.LiteralTextContent;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.Text;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -23,7 +25,7 @@ public class GameMessageConverter {
 
 
     private final String input;
-    private final LiteralText gameOutput;
+    private final MutableText gameOutput;
     private final StringBuilder discordOutput;
     private final TextChannel channel;
     private final JDA discord;
@@ -37,7 +39,7 @@ public class GameMessageConverter {
         this.input = input;
         this.channel = channel;
         this.discord = discord;
-        this.gameOutput = new LiteralText("");
+        this.gameOutput = Text.empty();
         this.discordOutput = new StringBuilder();
     }
 
@@ -144,15 +146,15 @@ public class GameMessageConverter {
 
     private void flushTextBuffer() {
         discordOutput.append(textBuffer);
-        gameOutput.append(new LiteralText(textBuffer.toString()));
+        gameOutput.append(textBuffer.toString());
         textBuffer.setLength(0);
     }
 
     public static class Results {
-        public final LiteralText gameOutput;
+        public final MutableText gameOutput;
         public final String discordOutput;
 
-        protected Results(LiteralText gameOutput, String discordOutput) {
+        protected Results(MutableText gameOutput, String discordOutput) {
             this.gameOutput = gameOutput;
             this.discordOutput = discordOutput;
         }

--- a/src/main/java/selic/re/discordbridge/UninitializedDiscordBot.java
+++ b/src/main/java/selic/re/discordbridge/UninitializedDiscordBot.java
@@ -50,7 +50,7 @@ final class UninitializedDiscordBot implements DiscordBot {
 
     @Override
     @Nullable
-    public Text formatAndSendMessage(GameProfile sender, String message) {
+    public Text formatAndSendMessage(GameProfile sender, Text message) {
         return null;
     }
 

--- a/src/main/java/selic/re/discordbridge/mixin/BroadcastHandlerMixin.java
+++ b/src/main/java/selic/re/discordbridge/mixin/BroadcastHandlerMixin.java
@@ -1,22 +1,24 @@
 package selic.re.discordbridge.mixin;
 
-import net.minecraft.network.MessageType;
+import net.minecraft.network.message.MessageType;
 import net.minecraft.server.PlayerManager;
+import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
+import net.minecraft.util.registry.RegistryKey;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import selic.re.discordbridge.DiscordBot;
 
-import java.util.UUID;
+import java.util.function.Function;
 
 @Mixin(PlayerManager.class)
 abstract class BroadcastHandlerMixin {
     @Inject(
-        method = "broadcast(Lnet/minecraft/text/Text;Lnet/minecraft/network/MessageType;Ljava/util/UUID;)V",
+        method = "broadcast(Lnet/minecraft/text/Text;Ljava/util/function/Function;Lnet/minecraft/util/registry/RegistryKey;)V",
         at = @At("HEAD"), require = 1)
-    private void preBroadcast(Text message, MessageType type, UUID sender, CallbackInfo info) {
+    private void preBroadcast(Text message, Function<ServerPlayerEntity, Text> playerMessageFactory, RegistryKey<MessageType> typeKey, CallbackInfo ci) {
         DiscordBot.instance().sendMessage(message);
     }
 }

--- a/src/main/java/selic/re/discordbridge/mixin/PlayerManagerMixin.java
+++ b/src/main/java/selic/re/discordbridge/mixin/PlayerManagerMixin.java
@@ -9,6 +9,7 @@ import net.minecraft.network.packet.s2c.play.PlayerListS2CPacket;
 import net.minecraft.server.PlayerManager;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
+import net.minecraft.util.dynamic.DynamicSerializableUuid;
 import net.minecraft.world.GameMode;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -40,10 +41,10 @@ abstract class PlayerManagerMixin {
                     continue;
                 }
                 PlayerListS2CPacket packet = new PlayerListS2CPacket(PlayerListS2CPacket.Action.ADD_PLAYER);
-                GameProfile profile = new GameProfile(PlayerEntity.getOfflinePlayerUuid(member.getId()), name);
+                GameProfile profile = new GameProfile(DynamicSerializableUuid.getOfflinePlayerUuid(member.getId()), name);
                 int latency = member.getOnlineStatus() == OnlineStatus.OFFLINE ? -1 : 10000;
                 Text displayName = DiscordFormattingConverter.discordUserToMinecraft(member.getUser(), member.getGuild(), false);
-                packet.getEntries().add(new PlayerListS2CPacket.Entry(profile, latency, GameMode.SPECTATOR, displayName));
+                packet.getEntries().add(new PlayerListS2CPacket.Entry(profile, latency, GameMode.SPECTATOR, displayName, null));
                 connection.send(packet);
             }
         }

--- a/src/main/java/selic/re/discordbridge/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/selic/re/discordbridge/mixin/ServerPlayerEntityMixin.java
@@ -2,11 +2,14 @@ package selic.re.discordbridge.mixin;
 
 import com.mojang.authlib.GameProfile;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.network.MessageType;
+import net.minecraft.network.encryption.PlayerPublicKey;
+import net.minecraft.network.message.MessageType;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.World;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -15,8 +18,9 @@ import selic.re.discordbridge.DiscordBot;
 
 @Mixin(ServerPlayerEntity.class)
 abstract class ServerPlayerEntityMixin extends PlayerEntity {
-    ServerPlayerEntityMixin(World world, BlockPos pos, float yaw, GameProfile profile) {
-        super(world, pos, yaw, profile);
+
+    public ServerPlayerEntityMixin(World world, BlockPos pos, float yaw, GameProfile gameProfile, @Nullable PlayerPublicKey publicKey) {
+        super(world, pos, yaw, gameProfile, publicKey);
     }
 
     @Inject(
@@ -30,9 +34,9 @@ abstract class ServerPlayerEntityMixin extends PlayerEntity {
     }
 
     @Inject(
-        method = "acceptsMessage(Lnet/minecraft/network/MessageType;)Z",
+        method = "acceptsMessage",
         at = @At("HEAD"), require = 1, cancellable = true)
-    private void acceptsMessage(MessageType type, CallbackInfoReturnable<Boolean> ci) {
+    private void acceptsMessage(RegistryKey<MessageType> type, CallbackInfoReturnable<Boolean> ci) {
         if (type == MessageType.CHAT && DiscordBot.instance().isChatHidden(this)) {
             ci.setReturnValue(false);
         }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -7,9 +7,9 @@
   "license": "MIT",
   "icon": "assets/discord-bridge/icon.png",
   "depends": {
-    "fabricloader": ">=0.11.6",
-    "minecraft": ">=1.17",
-    "java": ">=16"
+    "fabricloader": ">=0.14.6",
+    "minecraft": "~1.19-rc.2",
+    "java": ">=17"
   },
   "entrypoints": {
     "main": [

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -8,7 +8,7 @@
   "icon": "assets/discord-bridge/icon.png",
   "depends": {
     "fabricloader": ">=0.14.6",
-    "minecraft": "~1.19-rc.2",
+    "minecraft": ">=1.19",
     "java": ">=17"
   },
   "entrypoints": {

--- a/src/test/java/selic/re/discordbridge/TextToMarkdownVisitorTest.java
+++ b/src/test/java/selic/re/discordbridge/TextToMarkdownVisitorTest.java
@@ -1,10 +1,6 @@
 package selic.re.discordbridge;
 
-import net.minecraft.text.ClickEvent;
-import net.minecraft.text.HoverEvent;
-import net.minecraft.text.LiteralText;
-import net.minecraft.text.MutableText;
-import net.minecraft.text.Style;
+import net.minecraft.text.*;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -13,7 +9,7 @@ public final class TextToMarkdownVisitorTest {
     @Test
     public void boldStyleIsTokenized() {
         TextToMarkdownVisitor visitor = new TextToMarkdownVisitor();
-        MutableText bold = new LiteralText("This is bold");
+        MutableText bold = Text.empty().append("This is bold");
 
         bold.setStyle(Style.EMPTY.withBold(true));
         bold.visit(visitor, Style.EMPTY);
@@ -24,7 +20,7 @@ public final class TextToMarkdownVisitorTest {
     @Test
     public void italicStyleIsTokenized() {
         TextToMarkdownVisitor visitor = new TextToMarkdownVisitor();
-        MutableText italic = new LiteralText("This is italic");
+        MutableText italic = Text.empty().append("This is italic");
 
         italic.setStyle(Style.EMPTY.withItalic(true));
         italic.visit(visitor, Style.EMPTY);
@@ -35,7 +31,7 @@ public final class TextToMarkdownVisitorTest {
     @Test
     public void underlineStyleIsTokenized() {
         TextToMarkdownVisitor visitor = new TextToMarkdownVisitor();
-        MutableText underline = new LiteralText("This is underline");
+        MutableText underline = Text.empty().append("This is underline");
 
         underline.setStyle(Style.EMPTY.withUnderline(true));
         underline.visit(visitor, Style.EMPTY);
@@ -46,7 +42,7 @@ public final class TextToMarkdownVisitorTest {
     @Test
     public void strikethroughStyleIsTokenized() {
         TextToMarkdownVisitor visitor = new TextToMarkdownVisitor();
-        MutableText strikethrough = new LiteralText("This is strikethrough");
+        MutableText strikethrough = Text.empty().append("This is strikethrough");
 
         strikethrough.setStyle(Style.EMPTY.withStrikethrough(true));
         strikethrough.visit(visitor, Style.EMPTY);
@@ -57,7 +53,7 @@ public final class TextToMarkdownVisitorTest {
     @Test
     public void spoilerStyleIsTokenized() {
         TextToMarkdownVisitor visitor = new TextToMarkdownVisitor();
-        MutableText spoiler = new LiteralText("This is spoiler");
+        MutableText spoiler = Text.empty().append("This is spoiler");
 
         spoiler.setStyle(Style.EMPTY.withObfuscated(true));
         spoiler.visit(visitor, Style.EMPTY);
@@ -68,8 +64,8 @@ public final class TextToMarkdownVisitorTest {
     @Test
     public void styleWithHoverEventIsTokenized() {
         TextToMarkdownVisitor visitor = new TextToMarkdownVisitor();
-        MutableText component = new LiteralText("This has a hover event");
-        HoverEvent event = new HoverEvent(HoverEvent.Action.SHOW_TEXT, LiteralText.EMPTY);
+        MutableText component = Text.empty().append("This has a hover event");
+        HoverEvent event = new HoverEvent(HoverEvent.Action.SHOW_TEXT, Text.empty());
 
         component.setStyle(Style.EMPTY.withHoverEvent(event));
         component.visit(visitor, Style.EMPTY);
@@ -80,7 +76,7 @@ public final class TextToMarkdownVisitorTest {
     @Test
     public void styleWithClickEventIsTokenized() {
         TextToMarkdownVisitor visitor = new TextToMarkdownVisitor();
-        MutableText component = new LiteralText("This has a click event");
+        MutableText component = Text.empty().append("This has a click event");
         ClickEvent event = new ClickEvent(ClickEvent.Action.OPEN_URL, "");
 
         component.setStyle(Style.EMPTY.withClickEvent(event));
@@ -92,11 +88,11 @@ public final class TextToMarkdownVisitorTest {
     @Test
     public void nestedStylesAreTokenized() {
         TextToMarkdownVisitor visitor = new TextToMarkdownVisitor();
-        MutableText bold = new LiteralText("This is ").setStyle(Style.EMPTY.withBold(true));
-        MutableText italic = new LiteralText("italic, ").setStyle(Style.EMPTY.withItalic(true));
-        MutableText underlined = new LiteralText("underlined").setStyle(Style.EMPTY.withUnderline(true));
+        MutableText bold = Text.empty().append("This is ").setStyle(Style.EMPTY.withBold(true));
+        MutableText italic = Text.empty().append("italic, ").setStyle(Style.EMPTY.withItalic(true));
+        MutableText underlined = Text.empty().append("underlined").setStyle(Style.EMPTY.withUnderline(true));
 
-        bold.append(italic.append(underlined)).append(new LiteralText(", and bold"));
+        bold.append(italic.append(underlined)).append(Text.empty().append(", and bold"));
 
         bold.visit(visitor, Style.EMPTY);
 
@@ -106,7 +102,7 @@ public final class TextToMarkdownVisitorTest {
     @Test
     public void literalTokensAreEscaped() {
         TextToMarkdownVisitor visitor = new TextToMarkdownVisitor();
-        MutableText tokenized = new LiteralText("*These* __are__ ||literal|| `tokens`");
+        MutableText tokenized = Text.empty().append("*These* __are__ ||literal|| `tokens`");
 
         tokenized.visit(visitor, Style.EMPTY);
 

--- a/src/test/java/selic/re/discordbridge/TextToMarkdownVisitorTest.java
+++ b/src/test/java/selic/re/discordbridge/TextToMarkdownVisitorTest.java
@@ -9,7 +9,7 @@ public final class TextToMarkdownVisitorTest {
     @Test
     public void boldStyleIsTokenized() {
         TextToMarkdownVisitor visitor = new TextToMarkdownVisitor();
-        MutableText bold = Text.empty().append("This is bold");
+        MutableText bold = Text.literal("This is bold");
 
         bold.setStyle(Style.EMPTY.withBold(true));
         bold.visit(visitor, Style.EMPTY);
@@ -20,7 +20,7 @@ public final class TextToMarkdownVisitorTest {
     @Test
     public void italicStyleIsTokenized() {
         TextToMarkdownVisitor visitor = new TextToMarkdownVisitor();
-        MutableText italic = Text.empty().append("This is italic");
+        MutableText italic = Text.literal("This is italic");
 
         italic.setStyle(Style.EMPTY.withItalic(true));
         italic.visit(visitor, Style.EMPTY);
@@ -31,7 +31,7 @@ public final class TextToMarkdownVisitorTest {
     @Test
     public void underlineStyleIsTokenized() {
         TextToMarkdownVisitor visitor = new TextToMarkdownVisitor();
-        MutableText underline = Text.empty().append("This is underline");
+        MutableText underline = Text.literal("This is underline");
 
         underline.setStyle(Style.EMPTY.withUnderline(true));
         underline.visit(visitor, Style.EMPTY);
@@ -42,7 +42,7 @@ public final class TextToMarkdownVisitorTest {
     @Test
     public void strikethroughStyleIsTokenized() {
         TextToMarkdownVisitor visitor = new TextToMarkdownVisitor();
-        MutableText strikethrough = Text.empty().append("This is strikethrough");
+        MutableText strikethrough = Text.literal("This is strikethrough");
 
         strikethrough.setStyle(Style.EMPTY.withStrikethrough(true));
         strikethrough.visit(visitor, Style.EMPTY);
@@ -53,7 +53,7 @@ public final class TextToMarkdownVisitorTest {
     @Test
     public void spoilerStyleIsTokenized() {
         TextToMarkdownVisitor visitor = new TextToMarkdownVisitor();
-        MutableText spoiler = Text.empty().append("This is spoiler");
+        MutableText spoiler = Text.literal("This is spoiler");
 
         spoiler.setStyle(Style.EMPTY.withObfuscated(true));
         spoiler.visit(visitor, Style.EMPTY);
@@ -64,7 +64,7 @@ public final class TextToMarkdownVisitorTest {
     @Test
     public void styleWithHoverEventIsTokenized() {
         TextToMarkdownVisitor visitor = new TextToMarkdownVisitor();
-        MutableText component = Text.empty().append("This has a hover event");
+        MutableText component = Text.literal("This has a hover event");
         HoverEvent event = new HoverEvent(HoverEvent.Action.SHOW_TEXT, Text.empty());
 
         component.setStyle(Style.EMPTY.withHoverEvent(event));
@@ -76,7 +76,7 @@ public final class TextToMarkdownVisitorTest {
     @Test
     public void styleWithClickEventIsTokenized() {
         TextToMarkdownVisitor visitor = new TextToMarkdownVisitor();
-        MutableText component = Text.empty().append("This has a click event");
+        MutableText component = Text.literal("This has a click event");
         ClickEvent event = new ClickEvent(ClickEvent.Action.OPEN_URL, "");
 
         component.setStyle(Style.EMPTY.withClickEvent(event));
@@ -88,11 +88,11 @@ public final class TextToMarkdownVisitorTest {
     @Test
     public void nestedStylesAreTokenized() {
         TextToMarkdownVisitor visitor = new TextToMarkdownVisitor();
-        MutableText bold = Text.empty().append("This is ").setStyle(Style.EMPTY.withBold(true));
-        MutableText italic = Text.empty().append("italic, ").setStyle(Style.EMPTY.withItalic(true));
-        MutableText underlined = Text.empty().append("underlined").setStyle(Style.EMPTY.withUnderline(true));
+        MutableText bold = Text.literal("This is ").setStyle(Style.EMPTY.withBold(true));
+        MutableText italic = Text.literal("italic, ").setStyle(Style.EMPTY.withItalic(true));
+        MutableText underlined = Text.literal("underlined").setStyle(Style.EMPTY.withUnderline(true));
 
-        bold.append(italic.append(underlined)).append(Text.empty().append(", and bold"));
+        bold.append(italic.append(underlined)).append(Text.literal(", and bold"));
 
         bold.visit(visitor, Style.EMPTY);
 
@@ -102,7 +102,7 @@ public final class TextToMarkdownVisitorTest {
     @Test
     public void literalTokensAreEscaped() {
         TextToMarkdownVisitor visitor = new TextToMarkdownVisitor();
-        MutableText tokenized = Text.empty().append("*These* __are__ ||literal|| `tokens`");
+        MutableText tokenized = Text.literal("*These* __are__ ||literal|| `tokens`");
 
         tokenized.visit(visitor, Style.EMPTY);
 


### PR DESCRIPTION
This makes the mod work on 1.19.
Since the whole chat infrastructure has changed a bit, these changes consist of the following:

- Update fabric/loom/etc versions to 1.19 compatible ones.
- Update Mixin references to new method signatures.
- Update to the new Text class layout (things got moved around a lot in the game's code).
- Use the newly established fabric-message-api to apply the server side formatting rather than a Mixin. The game now supports the concept of a "chat decorator" for this very purpose. However, as it only allows a single decorator to exist at the same time, we can make use of Fabric's abstraction here to have our implementation be more robust and compatible with other mods.

Left to do:
- ~~Ensure no further changes are necessary between 1.19-rc2 and 1.19.~~
- ~~Update fabric.mod.json to use `~1.19` once the version has been fully released.~~
- Make sure this PR merges into a `1.19` branch in this repository