### PR TITLE
WIP: Port to 1.19.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,13 +45,13 @@ configurations {
 }
 
 dependencies {
-    minecraft "com.mojang:minecraft:1.19"
-    mappings "net.fabricmc:yarn:1.19+build.1:v2"
-    modImplementation "net.fabricmc:fabric-loader:0.14.6"
+    minecraft "com.mojang:minecraft:1.19.1-pre2"
+    mappings "net.fabricmc:yarn:1.19.1-pre2+build.2:v2"
+    modImplementation "net.fabricmc:fabric-loader:0.14.8"
 
-    modImplementation include(fabricApi.module("fabric-api-base", "0.55.2+1.19"))
-    modImplementation include(fabricApi.module("fabric-lifecycle-events-v1", "0.55.2+1.19"))
-    modImplementation include(fabricApi.module("fabric-message-api-v1", "0.55.2+1.19"))
+    modImplementation include(fabricApi.module("fabric-api-base", "0.57.1+1.19.1"))
+    modImplementation include(fabricApi.module("fabric-lifecycle-events-v1", "0.57.1+1.19.1"))
+    modImplementation include(fabricApi.module("fabric-message-api-v1", "0.57.1+1.19.1"))
 
     implementation(transitiveInclude("net.dv8tion:JDA:5.0.0-alpha.9")) {
         exclude module: "opus-java"

--- a/build.gradle
+++ b/build.gradle
@@ -45,13 +45,13 @@ configurations {
 }
 
 dependencies {
-    minecraft "com.mojang:minecraft:1.19.1-pre2"
-    mappings "net.fabricmc:yarn:1.19.1-pre2+build.2:v2"
-    modImplementation "net.fabricmc:fabric-loader:0.14.8"
+    minecraft "com.mojang:minecraft:1.19.2"
+    mappings "net.fabricmc:yarn:1.19.2+build.28:v2"
+    modImplementation "net.fabricmc:fabric-loader:0.14.10"
 
-    modImplementation include(fabricApi.module("fabric-api-base", "0.57.1+1.19.1"))
-    modImplementation include(fabricApi.module("fabric-lifecycle-events-v1", "0.57.1+1.19.1"))
-    modImplementation include(fabricApi.module("fabric-message-api-v1", "0.57.1+1.19.1"))
+    modImplementation include(fabricApi.module("fabric-api-base", "0.64.0+1.19.2"))
+    modImplementation include(fabricApi.module("fabric-lifecycle-events-v1", "0.64.0+1.19.2"))
+    modImplementation include(fabricApi.module("fabric-message-api-v1", "0.64.0+1.19.2"))
 
     implementation(transitiveInclude("net.dv8tion:JDA:5.0.0-alpha.9")) {
         exclude module: "opus-java"

--- a/src/main/java/selic/re/discordbridge/DiscordBot.java
+++ b/src/main/java/selic/re/discordbridge/DiscordBot.java
@@ -34,7 +34,9 @@ public interface DiscordBot {
     void sendMessage(GameProfile sender, String message);
 
     @Nullable
-    Text formatAndSendMessage(GameProfile sender, Text message);
+    Text formatGameMessage(GameProfile sender, Text message);
+
+    void formatAndSendMessage(Text message);
 
 
     void onPlayersChanged();

--- a/src/main/java/selic/re/discordbridge/DiscordBotImpl.java
+++ b/src/main/java/selic/re/discordbridge/DiscordBotImpl.java
@@ -27,7 +27,6 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.requests.ErrorResponse;
 import net.dv8tion.jda.api.requests.GatewayIntent;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.network.message.MessageType;
 import net.minecraft.network.packet.s2c.play.PlayerListS2CPacket;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.WhitelistEntry;
@@ -381,7 +380,7 @@ class DiscordBotImpl extends ListenerAdapter implements DiscordBot {
         server.sendMessage(message);
 
         for (ServerPlayerEntity serverPlayerEntity : server.getPlayerManager().getPlayerList()) {
-            serverPlayerEntity.sendMessage(message, MessageType.SYSTEM);
+            serverPlayerEntity.sendMessage(message, false);
         }
     }
 

--- a/src/main/java/selic/re/discordbridge/DiscordBotImpl.java
+++ b/src/main/java/selic/re/discordbridge/DiscordBotImpl.java
@@ -391,7 +391,7 @@ class DiscordBotImpl extends ListenerAdapter implements DiscordBot {
             return message;
         }
 
-        GameMessageConverter.Results results = convertGameMessage(message.getString(), chatChannel, discord);
+        GameMessageConverter.Results results = convertGameMessage(message, chatChannel, discord);
         sendMessage(author, results.discordOutput);
         return results.gameOutput;
     }

--- a/src/main/java/selic/re/discordbridge/DiscordBridgeMod.java
+++ b/src/main/java/selic/re/discordbridge/DiscordBridgeMod.java
@@ -43,7 +43,7 @@ public class DiscordBridgeMod implements ModInitializer {
 
         ServerMessageDecoratorEvent.EVENT.register(ServerMessageDecoratorEvent.STYLING_PHASE, (sender, message) -> {
             if (sender != null) {
-                Text messageText = DiscordBot.instance().formatAndSendMessage(sender.getGameProfile(), message);
+                Text messageText = DiscordBot.instance().formatGameMessage(sender.getGameProfile(), message);
                 return CompletableFuture.completedFuture(messageText);
             }
 

--- a/src/main/java/selic/re/discordbridge/GameMessageConverter.java
+++ b/src/main/java/selic/re/discordbridge/GameMessageConverter.java
@@ -25,6 +25,7 @@ public class GameMessageConverter {
 
     private final String input;
     private final MutableText gameOutput;
+    private boolean gameOutputDecorated = false;
     private final StringBuilder discordOutput;
     private final TextChannel channel;
     private final JDA discord;
@@ -42,10 +43,11 @@ public class GameMessageConverter {
         this.discordOutput = new StringBuilder();
     }
 
-    public static Results convertGameMessage(String input, TextChannel channel, JDA discord) {
-        GameMessageConverter converter = new GameMessageConverter(input, channel, discord);
+    public static Results convertGameMessage(Text message, TextChannel channel, JDA discord) {
+        GameMessageConverter converter = new GameMessageConverter(message.getString(), channel, discord);
         converter.readToEnd();
-        return new Results(converter.gameOutput, converter.discordOutput.toString());
+        Text gameMessage = (converter.gameOutputDecorated ? converter.gameOutput : message);
+        return new Results(gameMessage, converter.discordOutput.toString());
     }
 
     protected char read() {
@@ -135,12 +137,14 @@ public class GameMessageConverter {
         flushTextBuffer();
         discordOutput.append(member.getAsMention());
         gameOutput.append(discordUserToMinecraft(member.getUser(), member.getGuild(), true));
+        gameOutputDecorated = true;
     }
 
     private void insertEmote(Emote emote) {
         flushTextBuffer();
         discordOutput.append(emote.getAsMention());
         gameOutput.append(discordEmoteToMinecraft(emote));
+        gameOutputDecorated = true;
     }
 
     private void flushTextBuffer() {
@@ -150,10 +154,10 @@ public class GameMessageConverter {
     }
 
     public static class Results {
-        public final MutableText gameOutput;
+        public final Text gameOutput;
         public final String discordOutput;
 
-        protected Results(MutableText gameOutput, String discordOutput) {
+        protected Results(Text gameOutput, String discordOutput) {
             this.gameOutput = gameOutput;
             this.discordOutput = discordOutput;
         }

--- a/src/main/java/selic/re/discordbridge/UninitializedDiscordBot.java
+++ b/src/main/java/selic/re/discordbridge/UninitializedDiscordBot.java
@@ -50,8 +50,12 @@ final class UninitializedDiscordBot implements DiscordBot {
 
     @Override
     @Nullable
-    public Text formatAndSendMessage(GameProfile sender, Text message) {
+    public Text formatGameMessage(GameProfile sender, Text message) {
         return null;
+    }
+
+    @Override
+    public void formatAndSendMessage(Text message) {
     }
 
     @Override

--- a/src/main/java/selic/re/discordbridge/mixin/BroadcastHandlerMixin.java
+++ b/src/main/java/selic/re/discordbridge/mixin/BroadcastHandlerMixin.java
@@ -1,10 +1,8 @@
 package selic.re.discordbridge.mixin;
 
-import net.minecraft.network.message.MessageType;
 import net.minecraft.server.PlayerManager;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
-import net.minecraft.util.registry.RegistryKey;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -16,9 +14,9 @@ import java.util.function.Function;
 @Mixin(PlayerManager.class)
 abstract class BroadcastHandlerMixin {
     @Inject(
-        method = "broadcast(Lnet/minecraft/text/Text;Ljava/util/function/Function;Lnet/minecraft/util/registry/RegistryKey;)V",
+        method = "broadcast(Lnet/minecraft/text/Text;Ljava/util/function/Function;Z)V",
         at = @At("HEAD"), require = 1)
-    private void preBroadcast(Text message, Function<ServerPlayerEntity, Text> playerMessageFactory, RegistryKey<MessageType> typeKey, CallbackInfo ci) {
-        DiscordBot.instance().sendMessage(message);
+    private void preBroadcast(Text message, Function<ServerPlayerEntity, Text> playerMessageFactory, boolean actionBar, CallbackInfo ci) {
+        if (!actionBar) DiscordBot.instance().sendMessage(message);
     }
 }

--- a/src/main/java/selic/re/discordbridge/mixin/NetworkHandlerMixin.java
+++ b/src/main/java/selic/re/discordbridge/mixin/NetworkHandlerMixin.java
@@ -1,23 +1,27 @@
 package selic.re.discordbridge.mixin;
 
 import net.minecraft.network.listener.ServerPlayPacketListener;
-import net.minecraft.network.packet.c2s.play.ChatMessageC2SPacket;
-import net.minecraft.server.filter.FilteredMessage;
+import net.minecraft.network.message.MessageType;
+import net.minecraft.network.message.SignedMessage;
+import net.minecraft.server.PlayerManager;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
+import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.EntityTrackingListener;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import selic.re.discordbridge.DiscordBot;
 
 @Mixin(ServerPlayNetworkHandler.class)
 abstract class NetworkHandlerMixin implements EntityTrackingListener, ServerPlayPacketListener {
     @Inject(
-        method = "handleMessage",
+        method = "handleDecoratedMessage",
         at = @At("HEAD"), require = 1)
-    private void preMessage(ChatMessageC2SPacket packet, FilteredMessage<String> message, CallbackInfo ci) {
-        String str = message.raw();
+    private void preMessage(SignedMessage signedMessage, CallbackInfo ci) {
+        String str = signedMessage.getContent().getString();
+        DiscordBot.instance().formatAndSendMessage(signedMessage.getContent());
 
         if (str.startsWith("/me ")) {
             /*
@@ -26,7 +30,7 @@ abstract class NetworkHandlerMixin implements EntityTrackingListener, ServerPlay
              be changed to match the translatable string rather than hijacking this particular class.
              That said, it works. For now.
             */
-            DiscordBot.instance().sendMessage(getPlayer().getGameProfile(), "*" + str.substring("/me ".length()) + "*");
+            //DiscordBot.instance().sendMessage(getPlayer().getGameProfile(), "*" + str.substring("/me ".length()) + "*");
         }
     }
 }

--- a/src/main/java/selic/re/discordbridge/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/selic/re/discordbridge/mixin/ServerPlayerEntityMixin.java
@@ -32,7 +32,7 @@ abstract class ServerPlayerEntityMixin extends PlayerEntity {
     }
 
     @Inject(
-        method = "method_44706",
+        method = "acceptsChatMessage",
         at = @At("HEAD"), require = 1, cancellable = true)
     private void acceptsMessage(CallbackInfoReturnable<Boolean> ci) {
         if (DiscordBot.instance().isChatHidden(this)) {
@@ -40,7 +40,7 @@ abstract class ServerPlayerEntityMixin extends PlayerEntity {
         }
     }
     @Inject(
-        method = "method_44707",
+        method = "acceptsMessage",
         at = @At("HEAD"), require = 1, cancellable = true)
     private void acceptsMessage(boolean actionBar, CallbackInfoReturnable<Boolean> ci) {
         if (!actionBar && DiscordBot.instance().isChatHidden(this)) {

--- a/src/main/java/selic/re/discordbridge/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/selic/re/discordbridge/mixin/ServerPlayerEntityMixin.java
@@ -3,11 +3,9 @@ package selic.re.discordbridge.mixin;
 import com.mojang.authlib.GameProfile;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.network.encryption.PlayerPublicKey;
-import net.minecraft.network.message.MessageType;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
@@ -34,11 +32,20 @@ abstract class ServerPlayerEntityMixin extends PlayerEntity {
     }
 
     @Inject(
-        method = "acceptsMessage",
+        method = "method_44706",
         at = @At("HEAD"), require = 1, cancellable = true)
-    private void acceptsMessage(RegistryKey<MessageType> type, CallbackInfoReturnable<Boolean> ci) {
-        if (type == MessageType.CHAT && DiscordBot.instance().isChatHidden(this)) {
+    private void acceptsMessage(CallbackInfoReturnable<Boolean> ci) {
+        if (DiscordBot.instance().isChatHidden(this)) {
             ci.setReturnValue(false);
         }
     }
+    @Inject(
+        method = "method_44707",
+        at = @At("HEAD"), require = 1, cancellable = true)
+    private void acceptsMessage(boolean actionBar, CallbackInfoReturnable<Boolean> ci) {
+        if (!actionBar && DiscordBot.instance().isChatHidden(this)) {
+            ci.setReturnValue(false);
+        }
+    }
+
 }


### PR DESCRIPTION
1.19.1-pre2 has changed chat message handling things around again. Begin porting now so it's easier when 1.19.1 is finalised.

Right now, the mod *works* on 1.19.1-pre2, but all ingame message get the "modified" badge since we don't keep the signatures. Messages from Discord look fine.

Things to do:
- [x] Make the mod run and work on 1.19.1-pre2.
- [ ] Somehow make sure the signature works.
- [x] Update everything to 1.19.1 proper once released.

(Sadly, current yarn mappings aren't fully updated yet, so we have to use some intermediary names for now. But migrating to mojmap is again too big of a project for me to want to tackle.)